### PR TITLE
chore(deps): update default registry's baseline to `d5ec528843d29e3a52d745a64b469f810b2cedbf`

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "37d46edf0f2024c3d04997a2d432d59278ca1dff"
+      "baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
     },
     "registries": [
       {


### PR DESCRIPTION
This PR updates default registry's baseline to `d5ec528843d29e3a52d745a64b469f810b2cedbf`.