### PR TITLE
chore(deps): update default registry's baseline to `dd3097e305afa53f7b4312371f62058d2e665320`

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
+      "baseline": "dd3097e305afa53f7b4312371f62058d2e665320"
     },
     "registries": [
       {


### PR DESCRIPTION
This PR updates default registry's baseline to `dd3097e305afa53f7b4312371f62058d2e665320`.